### PR TITLE
Crocodile drop partboot

### DIFF
--- a/board/leica/crocodile/Kconfig
+++ b/board/leica/crocodile/Kconfig
@@ -12,4 +12,16 @@ config SYS_CONFIG_NAME
 config IMX_CONFIG
 	default "board/leica/crocodile/imximage-8mm-lpddr4.cfg"
 
+config LEICA_BOOTSCRIPT_EMMC_ADDR
+	hex "Bootscript address in blocks on eMMC"
+	default 0x32
+	help
+	  Address in blocks on eMMC bootscript is loaded from.
+
+config LEICA_BOOTSCRIPT_EMMC_SIZE
+	hex "Bootscript size in blocks on eMMC"
+	default 0x8
+	help
+	  Size in blocks of bootscript on eMMC.
+
 endif

--- a/cmd/mmc.c
+++ b/cmd/mmc.c
@@ -895,42 +895,6 @@ static int mmc_partconf_print(struct mmc *mmc, const char *varname)
 	return CMD_RET_SUCCESS;
 }
 
-static int do_mmc_partboot(struct cmd_tbl *cmdtp, int flag,
-			   int argc, char *const argv[])
-{
-	int dev;
-	struct mmc *mmc;
-	u8 boot, part;
-
-	if (argc != 3)
-		return CMD_RET_USAGE;
-
-	dev = simple_strtoul(argv[1], NULL, 10);
-	boot = simple_strtoul(argv[2], NULL, 10);
-
-	mmc = init_mmc_device(dev, false);
-	if (!mmc)
-		return CMD_RET_FAILURE;
-
-	if (IS_SD(mmc)) {
-		puts("PARTITION_CONFIG only exists on eMMC\n");
-		return CMD_RET_FAILURE;
-	}
-
-	if (mmc->part_config == MMCPART_NOAVAILABLE) {
-		printf("No part_config info for ver. 0x%x\n", mmc->version);
-		return CMD_RET_FAILURE;
-	}
-
-	part = EXT_CSD_EXTRACT_BOOT_PART(mmc->part_config);
-
-	if (part == boot) {
-		return CMD_RET_SUCCESS;
-	} else {
-		return CMD_RET_FAILURE;
-	}
-}
-
 static int do_mmc_partconf(struct cmd_tbl *cmdtp, int flag,
 			   int argc, char *const argv[])
 {
@@ -1093,7 +1057,6 @@ static struct cmd_tbl cmd_mmc[] = {
 	U_BOOT_CMD_MKENT(bootbus, 5, 0, do_mmc_bootbus, "", ""),
 	U_BOOT_CMD_MKENT(bootpart-resize, 4, 0, do_mmc_boot_resize, "", ""),
 	U_BOOT_CMD_MKENT(partconf, 5, 0, do_mmc_partconf, "", ""),
-	U_BOOT_CMD_MKENT(partboot, 3, 0, do_mmc_partboot, "", ""),
 	U_BOOT_CMD_MKENT(rst-function, 3, 0, do_mmc_rst_func, "", ""),
 #endif
 #if CONFIG_IS_ENABLED(CMD_MMC_RPMB)
@@ -1170,8 +1133,6 @@ U_BOOT_CMD(
 	"mmc partconf <dev> [[varname] | [<boot_ack> <boot_partition> <partition_access>]]\n"
 	" - Show or change the bits of the PARTITION_CONFIG field of the specified device\n"
 	"   If showing the bits, optionally store the boot_partition field into varname\n"
-	"mmc partboot dev boot_partition\n"
-	" - Return true if given boot_partition is specified in PARTITION_CONFIG, otherwise false\n"
 	"mmc rst-function <dev> <value>\n"
 	" - Change the RST_n_FUNCTION field of the specified device\n"
 	"   WARNING: This is a write-once field and 0 / 1 / 2 are the only valid values.\n"

--- a/include/configs/crocodile.h
+++ b/include/configs/crocodile.h
@@ -39,22 +39,24 @@
 	"initrd_addr=0x43800000\0" \
 	"loadaddr=0x40480000\0"    \
 	"mmcdev="__stringify(CONFIG_SYS_MMC_ENV_DEV)"\0" \
+	"bootscr_addr_blk="__stringify(CONFIG_LEICA_BOOTSCRIPT_EMMC_ADDR)"\0" \
+	"bootscr_size_blk="__stringify(CONFIG_LEICA_BOOTSCRIPT_EMMC_SIZE)"\0" \
 	"bootm_size=0x10000000\0" \
 	"loadbootscript="\
 		"mmc partconf ${mmcdev} boot_partition; " \
 		"if test \"${boot_partition}\" = \"1\"; then " \
-			"echo Loading 4KiB bootscript from boot0 +25KiB; " \
+			"echo Loading bootscript from boot0; " \
 			"mmc dev ${mmcdev} 1; " \
 		"elif test \"${boot_partition}\" = \"2\"; then " \
-			"echo Loading 4KiB bootscript from boot1 +25KiB; " \
+			"echo Loading bootscript from boot1; " \
 			"mmc dev ${mmcdev} 2; " \
 		"else " \
-			"echo Loading 4KiB bootscript from user partition +25KiB; " \
+			"echo Loading bootscript from user partition; " \
 		"fi; " \
-		"mmc read ${loadaddr} 32 8;" \
+		"mmc read ${loadaddr} ${bootscr_addr_blk} ${bootscr_size_blk};" \
 		"mmc dev ${mmcdev};\0" \
 	"bootscript=echo Running bootscript from mmc ...; " \
-		"source\0" \
+		"source\0"
 
 #define CONFIG_BOOTCOMMAND \
 	"mmc dev ${mmcdev}; "\

--- a/include/configs/crocodile.h
+++ b/include/configs/crocodile.h
@@ -41,10 +41,11 @@
 	"mmcdev="__stringify(CONFIG_SYS_MMC_ENV_DEV)"\0" \
 	"bootm_size=0x10000000\0" \
 	"loadbootscript="\
-		"if mmc partboot ${mmcdev} 1; then " \
+		"mmc partconf ${mmcdev} boot_partition; " \
+		"if test \"${boot_partition}\" = \"1\"; then " \
 			"echo Loading 4KiB bootscript from boot0 +25KiB; " \
 			"mmc dev ${mmcdev} 1; " \
-		"elif mmc partboot ${mmcdev} 2; then " \
+		"elif test \"${boot_partition}\" = \"2\"; then " \
 			"echo Loading 4KiB bootscript from boot1 +25KiB; " \
 			"mmc dev ${mmcdev} 2; " \
 		"else " \


### PR DESCRIPTION
We don't need to add a command to `mmc` for getting the active boot partition.
We can just use `mmc partconf`.